### PR TITLE
Implement trait From for Direction and Axis

### DIFF
--- a/src/bitboard/axis.rs
+++ b/src/bitboard/axis.rs
@@ -24,8 +24,14 @@ impl Axis {
             Axis::Vertical => Direction::N,
             Axis::DiagUpLeft => Direction::NW,
             Axis::DiagUpRight => Direction::NE,
-            _ => unimplemented!("You MUST not use this method with Axis::All")
+            Axis::All => Direction::All
         }
+    }
+}
+
+impl From<Direction> for Axis {
+    fn from(dir: Direction) -> Self {
+        dir.to_axis()
     }
 }
 

--- a/src/bitboard/direction.rs
+++ b/src/bitboard/direction.rs
@@ -1,3 +1,5 @@
+use super::axis::Axis;
+
 const ARRAY_SIZE: usize = 8;
 
 // TODO: Missing doc here
@@ -12,6 +14,28 @@ pub enum Direction {
     SE,
     SW,
     All
+}
+
+impl Direction {
+    pub fn to_axis(&self) -> Axis {
+        match self {
+            Direction::N => Axis::Vertical,
+            Direction::S => Axis::Vertical,
+            Direction::E => Axis::Horizontal,
+            Direction::W => Axis::Horizontal,
+            Direction::NE => Axis::DiagUpRight,
+            Direction::SW => Axis::DiagUpRight,
+            Direction::NW => Axis::DiagUpLeft,
+            Direction::SE => Axis::DiagUpLeft,
+            Direction::All => Axis::All
+        }
+    }
+}
+
+impl From<Axis> for Direction {
+    fn from(axis: Axis) -> Self {
+        axis.to_direction()
+    }
 }
 
 // TODO: Missing doc here

--- a/src/bitboard/tests.rs
+++ b/src/bitboard/tests.rs
@@ -259,6 +259,25 @@ fn test_iterate_on_axis_iterator() {
 }
 // #endregion Tests AxisIterator
 
+//=============================
+// Tests for trait From on Axis
+//=============================
+
+// #region Tests trait From on Axis
+#[test]
+fn test_into_direction_on_axis() {
+    // Arrange
+    let axises = [Axis::Vertical, Axis::Horizontal, Axis::DiagUpLeft, Axis::DiagUpRight];
+    let expected = [Direction::N, Direction::W, Direction::NW, Direction::NE];
+
+    // Act
+    let results: [Direction; 4] = [axises[0].into(), axises[1].into(), axises[2].into(), axises[3].into()];
+
+    // Assert
+    assert_eq!(expected, results);
+}
+// #endregion Tests trait From on Axis
+
 //===================================
 // Tests for struct DirectionIterator
 //===================================
@@ -277,6 +296,25 @@ fn test_iterate_on_direction_iterator() {
     assert_eq!(expect, result);
 }
 // #endregion Tests DirectionIterator
+
+//==================================
+// Tests for trait From on Direction
+//==================================
+
+// #region Tests trait From on Direction
+#[test]
+fn test_into_direction_on_direction() {
+    // Arrange
+    let directions = [Direction::N, Direction::W, Direction::NW, Direction::NE];
+    let expected = [Axis::Vertical, Axis::Horizontal, Axis::DiagUpLeft, Axis::DiagUpRight];
+
+    // Act
+    let results: [Axis; 4] = [directions[0].into(), directions[1].into(), directions[2].into(), directions[3].into()];
+
+    // Assert
+    assert_eq!(expected, results);
+}
+// #endregion Tests trait From on Direction
 
 //==================================================
 // Test for Display trait implementation on BitBoard


### PR DESCRIPTION
As the title says, this PR add the implementation of `into()` and `from()` for both type `Direction` and `Axis`.

If one needs a `Direction` but only has an `Axis`, then one can now use the trait implementation as follow:
```rust
let dir: Direction = Direction::N;
let axis: Axis = dir.into();

assert_eq!(Axis::Vertical, axis);
```
and the opposite is possible as well like so:
```rust
let axis: Axis = Axis::Horizontal;
let dir: Direction = axis.into();

assert_eq!(Direction::W, dir);
```