### PR TITLE
Add file for github action for Rust

### DIFF
--- a/.github/workflow/rust.yml
+++ b/.github/workflow/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
This little file should enable Github Action on the repo and target the rust part of the project.

If this PR is merged, any new PR and/or push on the develop branch should trigger Github Action which will be responsible for running the tests for us.