### PR TITLE
Implement Alpha Beta pruning in minimax

### DIFF
--- a/src/goban.rs
+++ b/src/goban.rs
@@ -16,6 +16,9 @@ pub enum Fscore {
 }
 
 impl Fscore {
+	pub const MIN: Self = Fscore::Value(isize::MIN);
+	pub const MAX: Self = Fscore::Value(isize::MAX);
+
 	pub fn is_win(&self) -> bool {
 		*self == Fscore::Win
 	}


### PR DESCRIPTION
This PR adds the feature Alpha Beta pruning which aims to reduce the time and resources needed to compute the next move to play.
It should speed up a bit the Algorithm process.

Fixes #29
Fixes #5