### PR TITLE
Prepare Node for implementation of capture when generating new nodes

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -25,8 +25,8 @@ impl Algorithm
     }
 
     /// Set the initial Node to a new state using the provided Goban.
-    pub fn update_initial_state(&mut self, initial_state: Goban) {
-        let new_initial_node = Node::new(initial_state, 0);
+    pub fn update_initial_state(&mut self, initial_state: Goban, last_move: BitBoard) {
+        let new_initial_node = Node::new(initial_state, 0, last_move);
         self.initial = new_initial_node;
     }
 
@@ -102,7 +102,7 @@ impl Algorithm
                 } else {
                     (*parent.get_item().get_player(), parent.get_item().get_enemy() | b)
                 };
-                Node::new(Goban::new(player, enemy), parent.get_depth() + 1)
+                Node::new(Goban::new(player, enemy), parent.get_depth() + 1, *b)
             })
             .collect()
     }
@@ -283,7 +283,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent));
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
 
         // Act
         let result = algo.get_potential_moves();
@@ -360,7 +360,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent));
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
 
         // Act
         let result = algo.get_potential_moves();
@@ -437,7 +437,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent));
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
 
         // Act
         let result = algo.get_potential_moves();
@@ -514,7 +514,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent));
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
 
         // Act
         let result = algo.get_potential_moves();
@@ -591,7 +591,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent));
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
 
         // Act
         let result = algo.get_potential_moves();
@@ -668,7 +668,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent));
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
 
         // Act
         let result = algo.get_potential_moves();
@@ -745,7 +745,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent));
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
 
         // Act
         let result = algo.get_potential_moves();
@@ -783,21 +783,22 @@ mod tests {
             0000000000000000000
         "));
         let initial = Goban::new(player, enemy);
+        let mut next_move = enemy;
         let mut algo = Algorithm::new();
 
         for _ in 0..10 {
-            algo.update_initial_state(initial);
-            let next_move = algo.get_next_move();
-            if next_move.is_none() { break; }
-            let next_move = next_move.unwrap();
+            algo.update_initial_state(initial, next_move);
+            let next_move_opt = algo.get_next_move();
+            if next_move_opt.is_none() { break; }
+            next_move = next_move_opt.unwrap();
             println!("Here is the next move to play for player:\n{}", next_move);
             player |= next_move;
             println!("Player's BitBoard:\n{}", player);
             let initial = Goban::new(enemy, player);
-            algo.update_initial_state(initial);
-            let next_move = algo.get_next_move();
-            if next_move.is_none() { break; }
-            let next_move = next_move.unwrap();
+            algo.update_initial_state(initial, next_move);
+            let next_move_opt = algo.get_next_move();
+            if next_move_opt.is_none() { break; }
+            next_move = next_move_opt.unwrap();
             println!("Here is the next move to play for enemy:\n{}", next_move);
             enemy |= next_move;
             println!("Enemy's BitBoard:\n{}", enemy);

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -25,8 +25,8 @@ impl Algorithm
     }
 
     /// Set the initial Node to a new state using the provided Goban.
-    pub fn update_initial_state(&mut self, initial_state: Goban, last_move: BitBoard) {
-        let new_initial_node = Node::new(initial_state, 0, last_move);
+    pub fn update_initial_state(&mut self, initial_state: Goban, last_move: BitBoard, player_captures: u8, opponent_captures:u8) {
+        let new_initial_node = Node::new(initial_state, 0, last_move, player_captures, opponent_captures);
         self.initial = new_initial_node;
     }
 
@@ -102,7 +102,7 @@ impl Algorithm
                 } else {
                     (*parent.get_item().get_player(), parent.get_item().get_enemy() | b)
                 };
-                Node::new(Goban::new(player, enemy), parent.get_depth() + 1, *b)
+                Node::new(Goban::new(player, enemy), parent.get_depth() + 1, *b, 0, 0)
             })
             .collect()
     }
@@ -200,19 +200,20 @@ impl Algorithm
 
     /// This mehtod is likely to change in a near future because I'm not sure what to return.
     /// For now it returns a BitBoard that contains the next move to play.
-    pub fn get_next_move(&mut self) -> Option<BitBoard> {
+    pub fn get_next_move(&mut self) -> Option<Node> {
         let next_state = Self::minimax(&mut self.initial, 1, Fscore::MIN, Fscore::MAX, true);
         if next_state == self.initial {
             None
         } else {
-            Some(next_state.get_item().get_player() ^ self.initial.get_item().get_player())
+            Some(next_state)
+            // Some(next_state.get_item().get_player() ^ self.initial.get_item().get_player())
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::goban::Goban;
+    use crate::{goban::Goban, tree::node::Node};
     use crate::bitboard::BitBoard;
     use crate::algorithm::Algorithm;
 
@@ -283,7 +284,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty(), 0, 0);
 
         // Act
         let result = algo.get_potential_moves();
@@ -360,7 +361,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty(), 0, 0);
 
         // Act
         let result = algo.get_potential_moves();
@@ -437,7 +438,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty(), 0, 0);
 
         // Act
         let result = algo.get_potential_moves();
@@ -514,7 +515,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty(), 0, 0);
 
         // Act
         let result = algo.get_potential_moves();
@@ -591,7 +592,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty(), 0, 0);
 
         // Act
         let result = algo.get_potential_moves();
@@ -668,7 +669,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty(), 0, 0);
 
         // Act
         let result = algo.get_potential_moves();
@@ -745,7 +746,7 @@ mod tests {
             0000000000000000000
         ");
         let mut algo = Algorithm::new();
-        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty());
+        algo.update_initial_state(Goban::new(player, opponent), BitBoard::empty(), 0, 0);
 
         // Act
         let result = algo.get_potential_moves();
@@ -782,27 +783,29 @@ mod tests {
             0000000000000000000
             0000000000000000000
         "));
-        let initial = Goban::new(player, enemy);
         let mut next_move = enemy;
         let mut algo = Algorithm::new();
+        let mut result_node = Node::default();
 
         for _ in 0..10 {
-            algo.update_initial_state(initial, next_move);
+            let initial = Goban::new(player, enemy);
+            algo.update_initial_state(initial, next_move, result_node.get_player_captures(), result_node.get_opponent_captures());
             let next_move_opt = algo.get_next_move();
             if next_move_opt.is_none() { break; }
-            next_move = next_move_opt.unwrap();
+            result_node = next_move_opt.unwrap();
+            next_move = result_node.get_item().get_player() ^ initial.get_player();
             println!("Here is the next move to play for player:\n{}", next_move);
             player |= next_move;
             println!("Player's BitBoard:\n{}", player);
             let initial = Goban::new(enemy, player);
-            algo.update_initial_state(initial, next_move);
+            algo.update_initial_state(initial, next_move, result_node.get_opponent_captures(), result_node.get_player_captures());
             let next_move_opt = algo.get_next_move();
             if next_move_opt.is_none() { break; }
-            next_move = next_move_opt.unwrap();
+            result_node = next_move_opt.unwrap();
+            next_move = result_node.get_item().get_player() ^ initial.get_player();
             println!("Here is the next move to play for enemy:\n{}", next_move);
             enemy |= next_move;
             println!("Enemy's BitBoard:\n{}", enemy);
-            let initial = Goban::new(player, enemy);
         }
         todo!();
     }

--- a/src/bitboard/new_pattern.rs
+++ b/src/bitboard/new_pattern.rs
@@ -98,6 +98,7 @@ impl Default for NewPattern {
 // TODO: Implement the missing methods (get the potential next moves according to the threats/opportunities, ...) in the right mod directly this time
 // TODO: Test all this as much as possible
 // TODO: Move the tests in a dedicated mod. Move every tests in a dedicated direcotry/files.
+// TODO: Handle captures when generating moves
 #[inline]
 pub fn match_pattern_base(
     player: BitBoard,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -16,7 +16,7 @@ impl Tree
     pub fn new(root_item: Goban) -> Self {
         Self {
             depth: 0,
-            root: Node::new(root_item, 0, BitBoard::empty())
+            root: Node::new(root_item, 0, BitBoard::empty(), 0, 0)
         }
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,7 +1,7 @@
 pub(crate) mod node;
 
 use node::Node;
-use crate::goban::Goban;
+use crate::{bitboard::BitBoard, goban::Goban};
 
 pub struct Tree
 {
@@ -16,7 +16,7 @@ impl Tree
     pub fn new(root_item: Goban) -> Self {
         Self {
             depth: 0,
-            root: Node::new(root_item, 0)
+            root: Node::new(root_item, 0, BitBoard::empty())
         }
     }
 }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -35,6 +35,8 @@ pub struct Node
     item: Goban,
     depth: usize,
     last_move: BitBoard,
+    player_captures: u8,
+    opponent_captures: u8,
     /// `branches` is a [`BinaryHeap`], wrapped in an [`Option`], which hold child nodes.
     /// The type `Branches` is used for convenience and is just an alias for `BinaryHeap<Rc<RefCell<Node>>>`.
     branches: Option<Branches>,
@@ -73,11 +75,13 @@ impl Hash for Node {
 }
 
 impl Node {
-    pub fn new(item: Goban, depth: usize, last_move: BitBoard) -> Self {
+    pub fn new(item: Goban, depth: usize, last_move: BitBoard, player_captures: u8, opponent_captures: u8) -> Self {
         Self {
             item,
             depth,
             last_move,
+            player_captures,
+            opponent_captures,
             branches: None
         }
     }
@@ -90,6 +94,14 @@ impl Node {
         self.depth
     }
 
+    pub fn get_player_captures(&self) -> u8 {
+        self.player_captures
+    }
+
+    pub fn get_opponent_captures(&self) -> u8 {
+        self.opponent_captures
+    }
+
     pub fn set_item_fscore(&mut self, fscore: Fscore) {
         self.item.set_fscore(fscore);
     }
@@ -99,7 +111,7 @@ impl Node {
     }
 
     pub fn add_branch(&mut self, item: Goban, last_move: BitBoard) -> Rc<RefCell<Self>> {
-        let new_node = Rc::new(RefCell::new(Self::new(item, self.depth + 1, last_move)));
+        let new_node = Rc::new(RefCell::new(Self::new(item, self.depth + 1, last_move, self.player_captures, self.opponent_captures)));
         let mut branches = self.branches.take().unwrap_or_default();
 
         branches.push(Rc::clone(&new_node));
@@ -164,11 +176,11 @@ mod tests {
             for i in 1..10 {
                 let mut bitboard = BitBoard::default();
                 bitboard.set(i, true);
-                vec.push(Node::new(Goban::new(bitboard, bitboard), n.depth + 1, BitBoard::empty()));
+                vec.push(Node::new(Goban::new(bitboard, bitboard), n.depth + 1, BitBoard::empty(), 0, 0));
             }
             vec
         };
-        let mut node = Node::new(Goban::default(), 0, BitBoard::empty());
+        let mut node = Node::new(Goban::default(), 0, BitBoard::empty(), 0, 0);
 
         // Act
         node.add_many_branches(closure, true);
@@ -186,6 +198,8 @@ mod tests {
             item: Goban::new(bitboard, bitboard),
             depth: 0,
             last_move: BitBoard::empty(),
+            player_captures: 0,
+            opponent_captures: 0,
             branches: Some(Branches::new())
         };
 
@@ -204,6 +218,8 @@ mod tests {
             item: Goban::new(bitboard, bitboard),
             depth: 0,
             last_move: BitBoard::empty(),
+            player_captures: 0,
+            opponent_captures: 0,
             branches: None
         };
 
@@ -223,18 +239,24 @@ mod tests {
                 item: Goban::new(bitboards[0], bitboards[1]),
                 depth: 1,
                 last_move: BitBoard::empty(),
+                player_captures: 0,
+                opponent_captures: 0,
                 branches: None
             })),
             Rc::new(RefCell::new(Node {
                 item: Goban::new(bitboards[1], bitboards[0]),
                 depth: 1,
                 last_move: BitBoard::empty(),
+                player_captures: 0,
+                opponent_captures: 0,
                 branches: None
             })),
             Rc::new(RefCell::new(Node {
                 item: Goban::new(bitboards[0], bitboards[0]),
                 depth: 1,
                 last_move: BitBoard::empty(),
+                player_captures: 0,
+                opponent_captures: 0,
                 branches: None
             }))
         );
@@ -246,6 +268,8 @@ mod tests {
             item: Goban::new(bitboards[1], bitboards[1]),
             depth: 0,
             last_move: BitBoard::empty(),
+            player_captures: 0,
+            opponent_captures: 0,
             branches: Some(branches)
         };
 
@@ -264,6 +288,8 @@ mod tests {
             item: Goban::new(bitboards[0], bitboards[1]),
             depth: 0,
             last_move: BitBoard::empty(),
+            player_captures: 0,
+            opponent_captures: 0,
             branches: None
         };
 
@@ -285,11 +311,11 @@ mod tests {
             for i in 1..10 {
                 let mut bitboard = BitBoard::default();
                 bitboard.set(i, true);
-                vec.push(Node::new(Goban::new(bitboard, bitboard), n.depth + 1, BitBoard::empty()));
+                vec.push(Node::new(Goban::new(bitboard, bitboard), n.depth + 1, BitBoard::empty(), 0, 0));
             }
             vec
         };
-        let mut node = Node::new(Goban::default(), 0, BitBoard::empty());
+        let mut node = Node::new(Goban::default(), 0, BitBoard::empty(), 0, 0);
 
         // Act
         node.add_many_branches(closure, true);


### PR DESCRIPTION
This PR simply adds a new property in the struct Node: last_move, which is of type BitBoard and will hold the move played for this Node.

It will be very useful for the implementation of the capture handling when generating the next moves.