### PR TITLE
Fix crash when AI plays first with DEPTH == 1

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -366,7 +366,7 @@ impl Algorithm {
         self.compute_initial_threats_for_player();
         let mut initial = self.initial.clone();
         let next_state = self.minimax(&mut initial, depth, Fscore::MIN, Fscore::MAX, true);
-        if next_state == self.initial {
+        if next_state.get_last_move() == self.initial.get_last_move() {
             None
         } else {
             Some(next_state)


### PR DESCRIPTION
For the record, the issue was that we were comparing the `FScore` value
of the initial `Node` and the one returned by `get_next_move` which at
this stage in the game is very likely to be 0 in both `Node`s.

The fix is quite easy to do, what we have to do is simply to compare
the `BitBoard` `last_move` of each `Node`.