### PR TITLE
Fix crash when playing with hint enabled

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -359,7 +359,6 @@ impl Algorithm {
         (result | (current_player + Direction::All)) & legal_open_cells
     }
 
-    // TODO: We maybe can do better here, self probably doesn't need to be mutable.
     // Maybe we should pass the initial Node directly without passing by the initial property of Algorithm?
     /// For now, it returns a BitBoard that contains the next move to play.
     pub fn get_next_move(&mut self, depth: u32) -> Option<Node> {

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -365,8 +365,7 @@ impl Algorithm {
         self.compute_initial_threats_for_player();
         let mut initial = self.initial.clone();
         let next_state = self.minimax(&mut initial, depth, Fscore::MIN, Fscore::MAX, true);
-        println!("Here is the initial state:\n{}", self.initial.get_last_move());
-        println!("Here is the result just before the if in get_next_move(depth: {}):\n{}", next_state.get_depth(), next_state.get_last_move());
+
         next_state
     }
 }

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -360,16 +360,14 @@ impl Algorithm {
     }
 
     // Maybe we should pass the initial Node directly without passing by the initial property of Algorithm?
-    /// For now, it returns a BitBoard that contains the next move to play.
-    pub fn get_next_move(&mut self, depth: u32) -> Option<Node> {
+    /// For now, it returns a Node that contains the next move to play.
+    pub fn get_next_move(&mut self, depth: u32) -> Node {
         self.compute_initial_threats_for_player();
         let mut initial = self.initial.clone();
         let next_state = self.minimax(&mut initial, depth, Fscore::MIN, Fscore::MAX, true);
-        if next_state.get_last_move() == self.initial.get_last_move() {
-            None
-        } else {
-            Some(next_state)
-        }
+        println!("Here is the initial state:\n{}", self.initial.get_last_move());
+        println!("Here is the result just before the if in get_next_move(depth: {}):\n{}", next_state.get_depth(), next_state.get_last_move());
+        next_state
     }
 }
 

--- a/src/algorithm/tests.rs
+++ b/src/algorithm/tests.rs
@@ -595,18 +595,14 @@ fn test_algorithm()
     for _ in 0..10 {
         let initial = Goban::new(player, enemy);
         algo.update_initial_state(initial, next_move, result_node.get_player_captures(), result_node.get_opponent_captures());
-        let next_move_opt = algo.get_next_move(2);
-        if next_move_opt.is_none() { break; }
-        result_node = next_move_opt.unwrap();
+        result_node = algo.get_next_move(2);
         next_move = result_node.get_item().get_player() ^ initial.get_player();
         println!("Here is the next move to play for player:\n{}", next_move);
         player |= next_move;
         println!("Player's BitBoard:\n{}", player);
         let initial = Goban::new(enemy, player);
         algo.update_initial_state(initial, next_move, result_node.get_opponent_captures(), result_node.get_player_captures());
-        let next_move_opt = algo.get_next_move(2);
-        if next_move_opt.is_none() { break; }
-        result_node = next_move_opt.unwrap();
+        result_node = algo.get_next_move(2);
         next_move = result_node.get_item().get_player() ^ initial.get_player();
         println!("Here is the next move to play for enemy:\n{}", next_move);
         enemy |= next_move;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ fn launch_ai(input: Goban, player_captures: u8, opponent_captures: u8, last_move
         BitBoard::empty()
     };
     algorithm.update_initial_state(input, last_move, player_captures, opponent_captures);
-    let ret = algorithm.get_next_move(DEPTH).unwrap();
+    let ret = algorithm.get_next_move(DEPTH);
 
     get_move_coord(&ret)
 }


### PR DESCRIPTION
This should fix the crash we have sometimes (actually, quite often) when playing with the help of the `hint` mode.
It's a bit complicated to explain in details what was wrong, but in a few words, the issue was that the Python part seems to keep the move returned by the AI for the hint (so, not a move that has actually been played) in memory and seems to send it to the Rust part just like it was an actual move played by one of the two players. So, if the AI wants to play this exact move, the Rust part would panic (because we compare the last move played with the move generated by the AI to determine if there is actually a move to play, this logic is not good at all, especially since there is just en `unwrap()` in the calling part. Also, this logic has no more reason to exist since the Python part now does a pretty good job at determining the end of the game).

Well, maybe a bit too many words here but I want to be sure we will be able to remember what was the issue and how we fixed it.

**WARNING**: There is probably something wrong in the Python part as well (it should not consider the move generated for the hint as an actual move for instance).