### PR TITLE
Try to make AI less stupid when dealing with open split three

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -283,6 +283,10 @@ impl Algorithm {
             opponent_captures,
             &self.patterns
         );
+        result &= legal_open_cells;
+        if result.is_any() {
+            return result;
+        }
         let is_threatened = result.is_any();
 
         // Get the moves that threat `opponent` because those are good move to play.


### PR DESCRIPTION
The idea here is to make the AI play a bit better against open split three which, for some reason, --don't ask why. I have no idea-- is unable to play a counter move against that.

This PR aims at fixing this behavior by making the method responsible for generating the potential next moves returns when there are threats, and by threats, I mean open split three obviously!